### PR TITLE
reset reporter while apply compiling

### DIFF
--- a/util-eval/src/main/scala/com/twitter/util/Eval.scala
+++ b/util-eval/src/main/scala/com/twitter/util/Eval.scala
@@ -580,6 +580,9 @@ class Eval(target: Option[File]) {
       if (Debug.enabled)
         Debug.printWithLineNumbers(code)
 
+      //reset reporter, or will always throw exception after one error while resetState==false
+      resetReporter()
+
       // if you're looking for the performance hit, it's 1/2 this line...
       val compiler = new global.Run
       val sourceFiles = List(new BatchSourceFile("(inline)", code))


### PR DESCRIPTION
reset reporter while apply compiling
I notice that the former release 6.36.0 reset the reporter after check(), which is not enough. I my use case, I would like to use apply with resetState=false (or simply inPlace), without check it before ( check method requires compiling every time, but apply method has cache).
Under such circumstance, if I offer a pice of code with syntax error, it will throw CompilerException every time even if I correct it. It’s because the reporter hasn’t been reset. Simply add resetReporter will solve the problem.
BTW, I strongly suggest that the Twitter Util continuously support java 7, I don’t see a strong motivation of give up the support. On the other hand, there ’s so many companies which still use java 7 in production environment ,which is that I meet with, that I have to merge some bug fix and new feature to old release manually.
